### PR TITLE
feat(geometry): smoother joints + correct mapping groundwork

### DIFF
--- a/frontend/public/corvid_crow_anim_v9.svg
+++ b/frontend/public/corvid_crow_anim_v9.svg
@@ -90,6 +90,13 @@
       <rect x="260" y="0" width="100" height="220"/>
       <rect x="260" y="340" width="100" height="398"/>
     </g></mask>
+    <mask id="maskNeckMid"><use href="#crowSil"/><g fill="black">
+      <!-- narrower intermediate neck segment for smoother head coupling -->
+      <rect x="0" y="0" width="280" height="738"/>
+      <rect x="340" y="0" width="369" height="738"/>
+      <rect x="280" y="0" width="60" height="240"/>
+      <rect x="280" y="320" width="60" height="418"/>
+    </g></mask>
     <mask id="maskWing"><use href="#crowSil"/><g fill="black">
       <!-- broad window for the wing area on the torso -->
       <rect x="0" y="0" width="190" height="738"/>
@@ -133,6 +140,7 @@
       <g id="WingC" class="feather" mask="url(#maskWingC)"><use href="#crowPNG"/></g>
     </g>
     <g id="Neck" class="part neck" mask="url(#maskNeck)"><use href="#crowPNG"/></g>
+    <g id="NeckMid" class="part neck" mask="url(#maskNeckMid)"><use href="#crowPNG"/></g>
     <g id="Head" class="part head" mask="url(#maskHead)">
       <use href="#crowPNG"/>
       <!-- Eyelids overlayed and clipped to silhouette; nested so they follow head transforms -->

--- a/frontend/src/lib/CrowRig.svelte
+++ b/frontend/src/lib/CrowRig.svelte
@@ -133,6 +133,7 @@
     const WINGA= { x: WING.x,         y: WING.y };
     const WINGB= { x: vb.width*0.40, y: vb.height*0.38 };
     const WINGC= { x: vb.width*0.48, y: vb.height*0.41 };
+    const NECKM= { x: vb.width*0.44, y: vb.height*0.26 };
     const BU   = { x: vb.width*0.60, y: vb.height*0.23 };
     const BL   = { x: vb.width*0.61, y: vb.height*0.26 };
     const TAIL = { x: vb.width*0.19, y: vb.height*0.62 };
@@ -144,6 +145,7 @@
     setOrigin('WingA', WINGA.x, WINGA.y);
     setOrigin('WingB', WINGB.x, WINGB.y);
     setOrigin('WingC', WINGC.x, WINGC.y);
+    setOrigin('NeckMid', NECKM.x, NECKM.y);
     setOrigin('BeakUpper', BU.x, BU.y);
     setOrigin('BeakLower', BL.x, BL.y);
     ['TailA','TailB','TailC','TailD'].forEach(id => setOrigin(id, TAIL.x, TAIL.y));
@@ -151,7 +153,7 @@
     setOrigin('FootRight', RFOOT.x, RFOOT.y);
 
     // Hint to engines that these nodes will animate transforms
-    ['Crow','Head','Wing','WingA','WingB','WingC','BeakUpper','BeakLower','TailA','TailB','TailC','TailD','Legs','Feet','FootLeft','FootRight']
+    ['Crow','Head','NeckMid','Wing','WingA','WingB','WingC','BeakUpper','BeakLower','TailA','TailB','TailC','TailD','Legs','Feet','FootLeft','FootRight']
       .forEach(id => { const el = svg.getElementById(id); if (el) el.style.willChange = 'transform'; });
   }
 
@@ -202,13 +204,19 @@
 
   function headBob(){
     const head = svg.getElementById('Head');
+    const neckm = svg.getElementById('NeckMid');
     if (!head) return Promise.resolve();
-    return head.animate(
+    const aH = head.animate(
       [{ transform:'translateY(0) rotate(0deg)' },
        { transform:'translateY(6px) rotate(-2deg)' },
        { transform:'translateY(0) rotate(0deg)' }],
       { duration: 900, easing:'cubic-bezier(.3,.6,.3,1)', fill:'none' }
-    ).finished;
+    );
+    const aN = neckm ? neckm.animate(
+      [{ transform:'rotate(0deg)' }, { transform:'rotate(-1deg)' }, { transform:'rotate(0deg)' }],
+      { duration: 900, easing:'cubic-bezier(.3,.6,.3,1)', fill:'none' }
+    ) : null;
+    return Promise.all([aH.finished, aN?.finished ?? Promise.resolve()]).then(()=>{});
   }
 
   function preen(){


### PR DESCRIPTION
## Summary
This PR begins smoothing polygon-like joints by adding an intermediate neck segment (NeckMid) and coupling it subtly during head bob. It builds on prior button mapping and reset work, ensuring actions return to neutral.

## Scope of changes
- frontend/public/corvid_crow_anim_v9.svg
  - Adds maskNeckMid and <g id=NeckMid> under Crow
- frontend/src/lib/CrowRig.svelte
  - Sets transform-origin for NeckMid
  - headBob(): adds a small rotation on NeckMid for curved motion

## How to test
1. bun run dev (frontend)
2. Head Bob (button or ambient) should show smoother connection at the neck
3. Verify seams remain hidden and pose resets to neutral per action

## Next steps (in this branch)
- Add leg joints (knee/ankle) and subtle coupling during hop/walk
- Add elbow/shoulder micro-rotations during preen

Closes #9
